### PR TITLE
Update wyzehub-meshlight-driver.groovy to include switch capability

### DIFF
--- a/WyzeHub/drivers/wyzehub-meshlight-driver.groovy
+++ b/WyzeHub/drivers/wyzehub-meshlight-driver.groovy
@@ -73,6 +73,7 @@ metadata {
 		capability "ColorControl"
 		capability "ColorMode"
 		capability "Refresh"
+		capability "Switch"
 		// capability "LightEffects"
 
 		command(


### PR DESCRIPTION
Added switch capability so color bulbs show up in basic rules.  Tested it on my local hubitat and seems to work without issue.